### PR TITLE
For use only for Linux machines

### DIFF
--- a/lib/facter/trust_bundle.rb
+++ b/lib/facter/trust_bundle.rb
@@ -1,4 +1,5 @@
 Facter.add('trust_bundle') do
+  confine kernel: 'Linux'
   setcode do
     osfacts = Facter.value(:os)
     case osfacts['family']


### PR DESCRIPTION
For use only for Linux machines, if there is windows, then an error occurs and the agent pours out